### PR TITLE
if getMiningProblem times out causing catch block to execute, and we …

### DIFF
--- a/src/tools/miner.cpp
+++ b/src/tools/miner.cpp
@@ -184,6 +184,8 @@ void get_work(PublicWalletAddress wallet, HostManager& hosts, block_status& stat
         } catch (const std::exception& e) {
             Logger::logError("run_mining", string(e.what()));
             host = hosts.getRandomHost().first;
+            latest_block_id = 0;
+            Logger::logStatus("Switching host to: " + host);
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         }
     }


### PR DESCRIPTION
if getMiningProblem() times out throwing "request timed out" error and causing catch block to execute the miner stalls because it believes it has already started work on the tip of the chain, when in fact it has not. 
