### PR TITLE
Add '--wallet' option to allow mining without private key exposure

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -26,6 +26,7 @@ json getConfig(int argc, char**argv) {
     std::vector<string>::iterator it;
     bool testnet = false;
     bool local = false;
+    string customWallet = "";
     string customIp = "";
     string customName = randomString(25);
     int customPort = 3000;
@@ -39,6 +40,11 @@ json getConfig(int argc, char**argv) {
     it = std::find(args.begin(), args.end(), "-t");
     if (it != args.end()) {
         threads = std::stoi(*++it);
+    }
+
+    it = std::find(args.begin(), args.end(), "--wallet");
+    if (it++ != args.end()) {
+        customWallet = string(*it);
     }
 
     it = std::find(args.begin(), args.end(), "--priority");
@@ -74,6 +80,7 @@ json getConfig(int argc, char**argv) {
 
     json config;
     config["threads"] = threads;
+    config["wallet"] = customWallet;
     config["port"] = customPort;
     config["name"] = customName;
     config["ip"] = customIp;

--- a/src/tools/miner.cpp
+++ b/src/tools/miner.cpp
@@ -226,20 +226,26 @@ int main(int argc, char **argv) {
     json config = getConfig(argc, argv);
     int threads = config["threads"];
     int thread_priority = config["thread_priority"];
+    string customWallet = config["wallet"];
+    PublicWalletAddress wallet;
 
     HostManager hosts(config);
     json keys;
-    try {
-        keys = readJsonFromFile("./keys.json");
-    } catch(...) {
-        Logger::logStatus("Could not read ./keys.json");
-        return 0;
+    if (customWallet == "") {
+        try {
+            keys = readJsonFromFile("./keys.json");
+        } catch(...) {
+            Logger::logStatus("Could not read ./keys.json");
+            return 0;
+        }
+        wallet = stringToWalletAddress(keys["wallet"]);
+        Logger::logStatus("Running miner. Coins stored in : " + string(keys["wallet"]));
+    } else {
+        wallet = stringToWalletAddress(customWallet);
+        Logger::logStatus("Running miner. Coins stored in : " + customWallet);
     }
         
     Logger::logStatus("Starting miner with " + to_string(threads) + " threads. Use -t X to change (for example: miner -t 6)");
-    
-    PublicWalletAddress wallet = stringToWalletAddress(keys["wallet"]);
-    Logger::logStatus("Running miner. Coins stored in : " + string(keys["wallet"]));
 
     block_status status;
 


### PR DESCRIPTION
This is a small patch which allows to specify `--wallet` option to `miner` so that `keys.json` is not mandatory anymore and no one will accidentally expose wallet private keys.